### PR TITLE
Don't create empty Manifest.toml

### DIFF
--- a/src/plugins/tests.jl
+++ b/src/plugins/tests.jl
@@ -57,6 +57,5 @@ function add_test_dependency(pkg_dir::AbstractString)
     write_project(path, toml)
 
     # Generate the manifest by updating the project.
-    touch(joinpath(pkg_dir, "Manifest.toml"))  # File must exist to be modified by Pkg.
     with_project(Pkg.update, pkg_dir)
 end


### PR DESCRIPTION
- close #365 
- Having an empty Manifest.toml seems to provoke a (slightly misleading) warning
- This change works fine on v1.8... but I imagine we did this for a reason, so i expect this will now fail CI on some old Julia version... since old Julia versions don't work on my laptop i'll rely on CI to complain. Probably we'll need an `if VERSION < ...` block [EDIT: nope seems fine as is 🤷 ]