### PR TITLE
Migrate links to JuliaCI/PkgTemplates.jl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PkgTemplates
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://invenia.github.io/PkgTemplates.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://invenia.github.io/PkgTemplates.jl/dev)
-[![CI](https://github.com/invenia/PkgTemplates.jl/workflows/CI/badge.svg)](https://github.com/invenia/PkgTemplates.jl/actions?query=workflow%3ACI)
-[![Codecov](https://codecov.io/gh/invenia/PkgTemplates.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/invenia/PkgTemplates.jl)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://juliaci.github.io/PkgTemplates.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliaci.github.io/PkgTemplates.jl/dev)
+[![CI](https://github.com/JuliaCI/PkgTemplates.jl/workflows/CI/badge.svg)](https://github.com/JuliaCI/PkgTemplates.jl/actions?query=workflow%3ACI)
+[![Codecov](https://codecov.io/gh/JuliaCI/PkgTemplates.jl/branch/master/graph/badge.svg?token=WsGRSymBmZ)](https://codecov.io/gh/JuliaCI/PkgTemplates.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
@@ -69,10 +69,10 @@ tpl = Template(;
 
 ---
 
-For a much more detailed overview, please see [the User Guide documentation](https://invenia.github.io/PkgTemplates.jl/stable/user/).
+For a much more detailed overview, please see [the User Guide documentation](https://juliaci.github.io/PkgTemplates.jl/stable/user/).
 
 ## Contributing
 
 Issues and pull requests are welcome!
 New contributors should make sure to read the [ColPrac Contributor Guide](https://github.com/SciML/ColPrac).
-For some more PkgTemplates-specific tips, see the [Developer Guide documentation](https://invenia.github.io/PkgTemplates.jl/stable/developer/).
+For some more PkgTemplates-specific tips, see the [Developer Guide documentation](https://juliaci.github.io/PkgTemplates.jl/stable/developer/).

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,11 +4,11 @@ using PkgTemplates: PkgTemplates
 makedocs(;
     modules=[PkgTemplates],
     authors="Chris de Graaf, Invenia Technical Computing Corporation",
-    repo="https://github.com/invenia/PkgTemplates.jl/blob/{commit}{path}#{line}",
+    repo="https://github.com/JuliaCI/PkgTemplates.jl/blob/{commit}{path}#{line}",
     sitename="PkgTemplates.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://invenia.github.io/PkgTemplates.jl",
+        canonical="https://juliaci.github.io/PkgTemplates.jl",
         assets=String[],
     ),
     pages=[
@@ -20,5 +20,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/invenia/PkgTemplates.jl",
+    repo="github.com/JuliaCI/PkgTemplates.jl",
 )

--- a/docs/src/developer.md
+++ b/docs/src/developer.md
@@ -11,7 +11,7 @@ Pages = ["developer.md"]
 Issues and pull requests are welcome!
 New contributors should make sure to read the [ColPrac Contributor Guide](https://github.com/SciML/ColPrac).
 
-[PkgTemplates](https://github.com/invenia/PkgTemplates.jl/) can be easily extended by adding new [`Plugin`](@ref)s.
+[PkgTemplates](https://github.com/JuliaCI/PkgTemplates.jl/) can be easily extended by adding new [`Plugin`](@ref)s.
 
 There are three types of plugins: [`Plugin`](@ref), [`FilePlugin`](@ref), and [`BadgePlugin`](@ref).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@ CurrentModule = PkgTemplates
 
 # PkgTemplates
 
-**[PkgTemplates](https://github.com/invenia/PkgTemplates.jl/) creates new Julia packages in an easy, repeatable, and customizable way.**
+**[PkgTemplates](https://github.com/JuliaCI/PkgTemplates.jl/) creates new Julia packages in an easy, repeatable, and customizable way.**
 
 ## Documentation
 

--- a/docs/src/migrating.md
+++ b/docs/src/migrating.md
@@ -55,8 +55,8 @@ Although it's unlikely that anyone used these.
 
 | Old                  | New                                                                                                  |
 | :------------------: | :--------------------------------------------------------------------------------------------------: |
-| `available_licenses` | [View licenses on GitHub](https://github.com/invenia/PkgTemplates.jl/tree/master/templates/licenses) |
-| `show_license`       | [View licenses on GitHub](https://github.com/invenia/PkgTemplates.jl/tree/master/templates/licenses) |
+| `available_licenses` | [View licenses on GitHub](https://github.com/JuliaCI/PkgTemplates.jl/tree/master/templates/licenses) |
+| `show_license`       | [View licenses on GitHub](https://github.com/JuliaCI/PkgTemplates.jl/tree/master/templates/licenses) |
 
 ## Custom Plugins
 

--- a/docs/src/user.md
+++ b/docs/src/user.md
@@ -8,7 +8,7 @@ CurrentModule = PkgTemplates
 Pages = ["user.md"]
 ```
 
-Using [PkgTemplates](https://github.com/invenia/PkgTemplates.jl/) is straightforward.
+Using [PkgTemplates](https://github.com/JuliaCI/PkgTemplates.jl/) is straightforward.
 Just create a [`Template`](@ref), and call it on a package name to generate that package:
 
 ```julia

--- a/src/plugins/license.jl
+++ b/src/plugins/license.jl
@@ -6,7 +6,7 @@ Creates a license file.
 ## Keyword Arguments
 - `name::AbstractString`: Name of a license supported by PkgTemplates.
   Available licenses can be seen
-  [here](https://github.com/invenia/PkgTemplates.jl/tree/master/templates/licenses).
+  [here](https://github.com/JuliaCI/PkgTemplates.jl/tree/master/templates/licenses).
 - `path::Union{AbstractString, Nothing}`: Path to a custom license file.
   This keyword takes priority over `name`.
 - `destination::AbstractString`: File destination, relative to the repository root.

--- a/test/plugin.jl
+++ b/test/plugin.jl
@@ -88,7 +88,7 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
         end
     end
 
-    # https://github.com/invenia/PkgTemplates.jl/issues/275
+    # https://github.com/JuliaCI/PkgTemplates.jl/issues/275
     @testset "makedocs_kwargs sort bug" begin
         p = Documenter(; makedocs_kwargs=Dict(:strict => true, :checkdocs => :exports))
         t = tpl(; plugins=[p])


### PR DESCRIPTION
Most of these redirected but it's good to update them anyways. Looks like docs got migrated without having to be regenerated, but Codecov will probably be empty until we have a successful test run. 