### PR TITLE
github & travis: dev package before building docs

### DIFF
--- a/src/plugins/documenter.jl
+++ b/src/plugins/documenter.jl
@@ -111,7 +111,7 @@ defaultkw(::Type{<:Documenter}, ::Val{:index_md}) = default_file("docs", "src", 
 defaultkw(::Type{<:Documenter}, ::Val{:devbranch}) = nothing
 defaultkw(::Type{<:Documenter}, ::Val{:edit_link}) = :devbranch
 
-gitignore(::Documenter) = ["/docs/build/"]
+gitignore(::Documenter) = ["/docs/build/", "/docs/Manifest.toml"]
 priority(::Documenter, ::Function) = DEFAULT_PRIORITY - 1  # We need SrcDir to go first.
 
 badges(::Documenter) = Badge[]

--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -73,6 +73,12 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
+      - name: Configure doc environment
+        run: |
+          julia --project=docs/ -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/templates/travis.yml
+++ b/templates/travis.yml
@@ -41,7 +41,13 @@ jobs:
   include:
     - stage: Documentation
       julia: 1
-      script: |
+      script:
+      - |
+        julia --project=docs -e '
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()'
+      - |
         julia --project=docs -e '
           using Pkg
           Pkg.develop(PackageSpec(path=pwd()))

--- a/test/fixtures/AllPlugins/.gitignore
+++ b/test/fixtures/AllPlugins/.gitignore
@@ -2,4 +2,5 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
+/docs/Manifest.toml
 /docs/build/

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -45,6 +45,12 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
+      - name: Configure doc environment
+        run: |
+          julia --project=docs/ -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/test/fixtures/DocumenterGitHubActions/.gitignore
+++ b/test/fixtures/DocumenterGitHubActions/.gitignore
@@ -1,2 +1,3 @@
 /Manifest.toml
+/docs/Manifest.toml
 /docs/build/

--- a/test/fixtures/DocumenterGitLabCI/.gitignore
+++ b/test/fixtures/DocumenterGitLabCI/.gitignore
@@ -2,4 +2,5 @@
 *.jl.cov
 *.jl.mem
 /Manifest.toml
+/docs/Manifest.toml
 /docs/build/

--- a/test/fixtures/DocumenterTravis/.gitignore
+++ b/test/fixtures/DocumenterTravis/.gitignore
@@ -1,2 +1,3 @@
 /Manifest.toml
+/docs/Manifest.toml
 /docs/build/

--- a/test/fixtures/DocumenterTravis/.travis.yml
+++ b/test/fixtures/DocumenterTravis/.travis.yml
@@ -20,7 +20,13 @@ jobs:
   include:
     - stage: Documentation
       julia: 1
-      script: |
+      script:
+      - |
+        julia --project=docs -e '
+          using Pkg
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.instantiate()'
+      - |
         julia --project=docs -e '
           using Pkg
           Pkg.develop(PackageSpec(path=pwd()))

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -45,6 +45,12 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
+      - name: Configure doc environment
+        run: |
+          julia --project=docs/ -e '
+            using Pkg
+            Pkg.develop(PackageSpec(path=pwd()))
+            Pkg.instantiate()'
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:

--- a/test/fixtures/WackyOptions/.gitignore
+++ b/test/fixtures/WackyOptions/.gitignore
@@ -1,6 +1,7 @@
 *.jl.*.cov
 *.jl.cov
 *.jl.mem
+/docs/Manifest.toml
 /docs/build/
 a
 b


### PR DESCRIPTION
The Documenter.jl docs say to dev the package before building the docs.
- https://github.com/JuliaDocs/Documenter.jl/blob/233a7822d670b063e894f62aea00729bcb3a28dd/docs/src/man/hosting.md?plain=1#L201-L202

The gitlab-ci script already does this, so this commit increases consistency.

This is also discussed in https://github.com/JuliaDocs/Documenter.jl/issues/1565 and https://discourse.julialang.org/t/documenter-jl-is-not-documenting-any-changes/94781/.

I also added `/docs/Manifest.toml` to the default `.gitignore`; this may be more controversial. I am happy to revert that.