### PR TITLE
Make testsets verbose

### DIFF
--- a/test/git.jl
+++ b/test/git.jl
@@ -1,7 +1,7 @@
 @info "Running Git tests"
 
-@testset "Git repositories" begin
-    @testset "Does not create Git repo" begin
+@testset verbose = true "Git repositories" begin
+    @testset verbose = true "Does not create Git repo" begin
         t = tpl(; plugins=[!Git])
         with_pkg(t) do pkg
             pkg_dir = joinpath(t.dir, pkg)
@@ -9,7 +9,7 @@
         end
     end
 
-    @testset "Creates Git repo" begin
+    @testset verbose = true "Creates Git repo" begin
         t = tpl(; plugins=[Git()])
         with_pkg(t) do pkg
             pkg_dir = joinpath(t.dir, pkg)
@@ -17,7 +17,7 @@
         end
     end
 
-    @testset "With HTTPS" begin
+    @testset verbose = true "With HTTPS" begin
         t = tpl(; plugins=[Git(; ssh=false)])
         with_pkg(t) do pkg
             LibGit2.with(GitRepo(joinpath(t.dir, pkg))) do repo
@@ -27,7 +27,7 @@
         end
     end
 
-    @testset "With SSH" begin
+    @testset verbose = true "With SSH" begin
         t = tpl(; plugins=[Git(; ssh=true)])
         with_pkg(t) do pkg
             LibGit2.with(GitRepo(joinpath(t.dir, pkg))) do repo
@@ -37,7 +37,7 @@
         end
     end
 
-    @testset "Without .jl suffix" begin
+    @testset verbose = true "Without .jl suffix" begin
         t = tpl(; plugins=[Git(; jl=false)])
         with_pkg(t) do pkg
             LibGit2.with(GitRepo(joinpath(t.dir, pkg))) do repo
@@ -47,7 +47,7 @@
         end
     end
 
-    @testset "With custom name/email" begin
+    @testset verbose = true "With custom name/email" begin
         t = tpl(; plugins=[Git(; name="me", email="a@b.c")])
         with_pkg(t) do pkg
             LibGit2.with(GitRepo(joinpath(t.dir, pkg))) do repo
@@ -57,7 +57,7 @@
         end
     end
 
-    @testset "Default branches" begin
+    @testset verbose = true "Default branches" begin
         with_clean_gitconfig() do
             @test Git().branch == PT.DEFAULT_DEFAULT_BRANCH
             run(`git config init.defaultBranch foo`)
@@ -72,7 +72,7 @@
         end
     end
 
-    @testset "Adds version to commit message" begin
+    @testset verbose = true "Adds version to commit message" begin
         # We're careful to avoid a Pkg.update as it triggers Cassette#130.
         t = tpl(; plugins=[Git(), !Tests])
 

--- a/test/interactive.jl
+++ b/test/interactive.jl
@@ -22,8 +22,8 @@ struct FromString
     s::String
 end
 
-@testset "Interactive mode" begin
-    @testset "Input conversion" begin
+@testset verbose = true "Interactive mode" begin
+    @testset verbose = true "Input conversion" begin
         generic(T, x) = PT.convert_input(PT.Plugin, T, x)
         @test generic(String, "foo") == "foo"
         @test generic(Float64, "1.23") == 1.23
@@ -46,7 +46,7 @@ end
         @test_throws ArgumentError generic(Bool, "hello")
     end
 
-    @testset "input_tips" begin
+    @testset verbose = true "input_tips" begin
         @test isempty(PT.input_tips(String))
         @test PT.input_tips(Int) == ["Int"]
         @test PT.input_tips(Bool) == ["Bool"]
@@ -59,7 +59,7 @@ end
             ["name only", "comma-delimited", "'nothing' for nothing"]
     end
 
-    @testset "Interactive name/type pair collection" begin
+    @testset verbose = true "Interactive name/type pair collection" begin
         name = gensym()
         @eval begin
             PT.@plugin struct $name <: PT.Plugin
@@ -73,8 +73,8 @@ end
         end
     end
 
-    @testset "Simulated inputs" begin
-        @testset "Default template" begin
+    @testset verbose = true "Simulated inputs" begin
+        @testset verbose = true "Default template" begin
             print(
                 stdin.buffer,
                 CR,        # Select user
@@ -84,7 +84,7 @@ end
             @test Template(; interactive=true) == Template(; user=USER)
         end
 
-        @testset "Custom options, accept defaults" begin
+        @testset verbose = true "Custom options, accept defaults" begin
             print(
                 stdin.buffer,
                 ALL, DONE,        # Customize all fields
@@ -101,7 +101,7 @@ end
             readavailable(stdin.buffer)
         end
 
-        @testset "Custom options, custom values" begin
+        @testset verbose = true "Custom options, custom values" begin
             nversions = VERSION.minor + 1
             print(
                 stdin.buffer,
@@ -127,7 +127,7 @@ end
             readavailable(stdin.buffer)
         end
 
-        @testset "Disabling default plugins" begin
+        @testset verbose = true "Disabling default plugins" begin
             print(
                 stdin.buffer,
                 CR, DOWN^5, CR, DONE,    # Customize user and plugins
@@ -143,7 +143,7 @@ end
             readavailable(stdin.buffer)
         end
 
-        @testset "Plugins" begin
+        @testset verbose = true "Plugins" begin
             print(
                 stdin.buffer,
                 ALL, DONE,       # Customize all fields
@@ -188,7 +188,7 @@ end
             @test PT.interactive(License) == License(; destination="COPYING", name="MIT")
         end
 
-        @testset "Quotes" begin
+        @testset verbose = true "Quotes" begin
             print(
                 stdin.buffer,
                 CR, DOWN^2, CR, DONE,  # Customize user and dir
@@ -212,7 +212,7 @@ end
             )
         end
 
-        @testset "Union{T, Nothing} weirdness" begin
+        @testset verbose = true "Union{T, Nothing} weirdness" begin
             print(
                 stdin.buffer,
                 DOWN, CR, DONE,  # Customize changelog
@@ -228,7 +228,7 @@ end
             @test PT.interactive(TagBot) == TagBot(; changelog=nothing)
         end
 
-        @testset "Only one field" begin
+        @testset verbose = true "Only one field" begin
             print(
                 stdin.buffer,
                 DOWN, CR, DONE,  # Select "None" option
@@ -236,7 +236,7 @@ end
             @test PT.interactive(Codecov) == Codecov()
         end
 
-        @testset "Missing user" begin
+        @testset verbose = true "Missing user" begin
             print(
                 stdin.buffer,
                 DONE,            # Customize nothing
@@ -249,7 +249,7 @@ end
             end
         end
 
-        @testset "Interrupts" begin
+        @testset verbose = true "Interrupts" begin
             print(
                 stdin.buffer,
                 SIGINT,  # Send keyboard interrupt

--- a/test/plugin.jl
+++ b/test/plugin.jl
@@ -14,8 +14,8 @@ PT.badges(::FileTest) = PT.Badge("{{X}}", "{{Y}}", "{{Z}}")
 PT.view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 0, "Y" => 2)
 PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3)
 
-@testset "Plugins" begin
-    @testset "FilePlugin" begin
+@testset verbose = true "Plugins" begin
+    @testset verbose = true "FilePlugin" begin
         p = FileTest("foo", true)
         t = tpl(; plugins=[p])
 
@@ -32,7 +32,7 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
         end
     end
 
-    @testset "Tests Project.toml warning on Julia < 1.2" begin
+    @testset verbose = true "Tests Project.toml warning on Julia < 1.2" begin
         p = Tests(; project=true)
         @test_logs (:warn, r"The project option is set") tpl(; julia=v"1", plugins=[p])
         @test_logs (:warn, r"The project option is set") tpl(; julia=v"1.1", plugins=[p])
@@ -40,14 +40,14 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
         @test_logs tpl(; julia=v"1.3", plugins=[p])
     end
 
-    @testset "CI versions" begin
+    @testset verbose = true "CI versions" begin
         t = tpl(; julia=v"1")
         @test PT.collect_versions(t, ["1.0", "1.5", "nightly"]) == ["1.0", "1.5", "nightly"]
         t = tpl(; julia=v"2")
         @test PT.collect_versions(t, ["1.0", "1.5", "nightly"]) == ["2.0", "nightly"]
     end
 
-    @testset "Equality" begin
+    @testset verbose = true "Equality" begin
         a = FileTest("foo", true)
         b = FileTest("foo", true)
         @test a == b
@@ -55,7 +55,7 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
         @test a != c
     end
 
-    @testset "Validations" begin
+    @testset verbose = true "Validations" begin
         t = tpl()
         p = TravisCI(; file="/does/not/exist")
         @test_throws ArgumentError PT.validate(p, t)
@@ -67,13 +67,13 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
         @test_throws ArgumentError PT.validate(p, t)
     end
 
-    @testset "Custom badge plugins" begin
+    @testset verbose = true "Custom badge plugins" begin
         t = tpl(; plugins=[!Readme, BlueStyleBadge()])
         with_pkg(t) do pkg
             pkg_dir = joinpath(t.dir, pkg)
             @test !isfile(joinpath(pkg_dir, "README.md"))
         end
-        @testset "$BadgeType" for (BadgeType, text) in (
+        @testset verbose = true "$BadgeType" for (BadgeType, text) in (
             BlueStyleBadge => "BlueStyle",
             ColPracBadge => "ColPrac",
             PkgEvalBadge => "PkgEval",
@@ -89,7 +89,7 @@ PT.user_view(::FileTest, ::Template, ::AbstractString) = Dict("X" => 1, "Z" => 3
     end
 
     # https://github.com/JuliaCI/PkgTemplates.jl/issues/275
-    @testset "makedocs_kwargs sort bug" begin
+    @testset verbose = true "makedocs_kwargs sort bug" begin
         p = Documenter(; makedocs_kwargs=Dict(:strict => true, :checkdocs => :exports))
         t = tpl(; plugins=[p])
         # A failure looks like: `MethodError: no method matching isless(::Symbol, ::Bool)`

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -81,12 +81,12 @@ function test_all(pkg::AbstractString; kwargs...)
     end
 end
 
-@testset "Reference tests" begin
-    @testset "Default package" begin
+@testset verbose = true "Reference tests" begin
+    @testset verbose = true "Default package" begin
         test_all("Basic"; authors=USER)
     end
 
-    @testset "All plugins" begin
+    @testset verbose = true "All plugins" begin
         test_all("AllPlugins"; authors=USER, plugins=[
             AppVeyor(), CirrusCI(), Citation(), Codecov(), CompatHelper(), Coveralls(), CodeOwners(),
             Dependabot(), Develop(), Documenter(), DroneCI(), GitHubActions(), GitLabCI(), TravisCI(),
@@ -94,25 +94,25 @@ end
         ])
     end
 
-    @testset "Documenter (TravisCI)" begin
+    @testset verbose = true "Documenter (TravisCI)" begin
         test_all("DocumenterTravis"; authors=USER, plugins=[
             Documenter{TravisCI}(), TravisCI(),
         ])
     end
 
-    @testset "Documenter (GitHubActions)" begin
+    @testset verbose = true "Documenter (GitHubActions)" begin
         test_all("DocumenterGitHubActions"; authors=USER, plugins=[
             Documenter{GitHubActions}(), GitHubActions(),
         ])
     end
 
-    @testset "Documenter (GitLabCI)" begin
+    @testset verbose = true "Documenter (GitLabCI)" begin
         test_all("DocumenterGitLabCI"; authors=USER, plugins=[
             Documenter{GitLabCI}(), GitLabCI(),
         ])
     end
 
-    @testset "Wacky options" begin
+    @testset verbose = true "Wacky options" begin
         test_all("WackyOptions"; authors=USER, julia=v"1.2", host="x.com", plugins=[
             AppVeyor(; x86=true, coverage=true, extra_versions=[v"1.1"]),
             CirrusCI(; image="freebsd-123", coverage=false, extra_versions=["1.3"]),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -90,7 +90,7 @@ mktempdir() do dir
     Pkg.activate(dir)
     pushfirst!(DEPOT_PATH, dir)
     try
-        @testset "PkgTemplates.jl" begin
+        @testset verbose = true "PkgTemplates.jl" begin
             include("template.jl")
             include("plugin.jl")
             include("show.jl")

--- a/test/show.jl
+++ b/test/show.jl
@@ -12,8 +12,8 @@ function test_show(expected::AbstractString, observed::AbstractString)
     end
 end
 
-@testset "Show methods" begin
-    @testset "Plugins" begin
+@testset verbose = true "Show methods" begin
+    @testset verbose = true "Plugins" begin
         expected = """
             Readme:
               file: "$(joinpath(TEMPLATES_DIR, "README.md"))"
@@ -25,7 +25,7 @@ end
         test_show(rstrip(expected), sprint(show, MIME("text/plain"), Readme()))
     end
 
-    @testset "Template" begin
+    @testset verbose = true "Template" begin
         expected = """
             Template:
               authors: ["$USER"]
@@ -106,7 +106,7 @@ end
         end
     end
 
-    @testset "show as serialization" begin
+    @testset verbose = true "show as serialization" begin
         t1 = tpl()
         t2 = eval(Meta.parse(sprint(show, t1)))
         @test t1 == t2

--- a/test/template.jl
+++ b/test/template.jl
@@ -1,8 +1,8 @@
 @info "Running template tests"
 
-@testset "Template" begin
-    @testset "Template constructor" begin
-        @testset "user" begin
+@testset verbose = true "Template" begin
+    @testset verbose = true "Template constructor" begin
+        @testset verbose = true "user" begin
             msg = sprint(showerror, PT.MissingUserException{TravisCI}())
             @test startswith(msg, "TravisCI: ")
 
@@ -18,24 +18,24 @@
             end
         end
 
-        @testset "authors" begin
+        @testset verbose = true "authors" begin
             @test tpl(; authors=["a"]).authors == ["a"]
             @test tpl(; authors="a").authors == ["a"]
             @test tpl(; authors="a,b").authors == ["a", "b"]
             @test tpl(; authors="a, b").authors == ["a", "b"]
         end
 
-        @testset "host" begin
+        @testset verbose = true "host" begin
             @test tpl(; host="https://foo.com").host == "foo.com"
         end
 
-        @testset "dir" begin
+        @testset verbose = true "dir" begin
             @test tpl(; dir="/foo/bar").dir == joinpath(path_separator, "foo", "bar")
             @test tpl(; dir="foo").dir == abspath("foo")
             @test tpl(; dir="~/foo").dir == abspath(expanduser("~/foo"))
         end
 
-        @testset "plugins" begin
+        @testset verbose = true "plugins" begin
             function test_plugins(plugins, expected)
                 t = tpl(; plugins=plugins)
                 @test all(map(==, sort(t.plugins; by=string), sort(expected; by=string)))
@@ -52,13 +52,13 @@
             test_plugins([!Git], setdiff(defaults, [default_g]))
         end
 
-        @testset "Unsupported keywords warning" begin
+        @testset verbose = true "Unsupported keywords warning" begin
             @test_logs tpl()
             @test_logs (:warn, r"Unrecognized keywords were supplied") tpl(; x=1, y=2)
         end
     end
 
-    @testset "Equality" begin
+    @testset verbose = true "Equality" begin
         a = tpl()
         b = tpl()
         @test a == b
@@ -66,7 +66,7 @@
         @test a != c
     end
 
-    @testset "hasplugin" begin
+    @testset verbose = true "hasplugin" begin
         t = tpl(; plugins=[TravisCI(), Documenter{TravisCI}()])
         @test PT.hasplugin(t, typeof(first(PT.default_plugins())))
         @test PT.hasplugin(t, Documenter)
@@ -76,7 +76,7 @@
         @test !PT.hasplugin(t, Citation)
     end
 
-    @testset "validate" begin
+    @testset verbose = true "validate" begin
         foreach((GitHubActions, TravisCI, GitLabCI)) do T
             @test_throws ArgumentError tpl(; plugins=[!GitHubActions, Documenter{T}()])
         end
@@ -88,7 +88,7 @@
     end
 end
 
-@testset "Package generation errors" begin
+@testset verbose = true "Package generation errors" begin
     mktempdir() do dir
         t = tpl(; dir=dirname(dir))
         @test_throws ArgumentError t(basename(dir))


### PR DESCRIPTION
Really just a find+replace of `@testset` with `@testset verbose = true` for more granularity in the test results.

I took care not to modify the `runtests.jl` of the templates, this change is restricted to the actual tests of PkgTemplates.jl itself