### PR TITLE
Don't create empty Manifest.toml (again)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.43"
+version = "0.7.44"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/plugins/git.jl
+++ b/src/plugins/git.jl
@@ -103,7 +103,6 @@ function posthook(p::Git, ::Template, pkg_dir::AbstractString)
     # Ensure that the manifest exists if it's going to be committed.
     manifest = joinpath(pkg_dir, "Manifest.toml")
     if p.manifest && !isfile(manifest)
-        touch(manifest)
         with_project(Pkg.update, pkg_dir)
     end
 

--- a/test/fixtures/WackyOptions/Manifest.toml
+++ b/test/fixtures/WackyOptions/Manifest.toml
@@ -1,2 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
+julia_version = "1.7.2"
+manifest_format = "2.0"
+
+[deps]


### PR DESCRIPTION
Follow-up to https://github.com/JuliaCI/PkgTemplates.jl/pull/425. The `Git` plugin was also `touch`ing an empty Manifest.toml which also triggered the warning. This fixes that.