### PR TITLE
Use CI caching for documentation job and add newly required perms

### DIFF
--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -17,6 +17,9 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
+      actions: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -67,6 +70,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     permissions:
+      actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
       contents: write
       statuses: write
     steps:
@@ -74,6 +78,7 @@ jobs:
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1'
+      - uses: julia-actions/cache@v1
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
         run: |


### PR DESCRIPTION
See new perm requirements in https://github.com/julia-actions/cache/releases/tag/v1.4.0

Note that they're not mandatory, just that tidying up happens more efficiently if they are in place, and lowers the chance of a useful cache being auto-deleted by Github