### PR TITLE
Remove repo argument to makedocs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,7 +7,6 @@ makedocs(;
     sitename="PkgTemplates.jl",
     format=Documenter.HTML(;
         repolink="https://github.com/JuliaCI/PkgTemplates.jl",
-        prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://juliaci.github.io/PkgTemplates.jl",
         assets=String[],
     ),

--- a/templates/docs/make.jl
+++ b/templates/docs/make.jl
@@ -6,7 +6,6 @@ DocMeta.setdocmeta!({{{PKG}}}, :DocTestSetup, :(using {{{PKG}}}); recursive=true
 makedocs(;
     modules=[{{{PKG}}}],
     authors="{{{AUTHORS}}}",
-    repo="https://{{{REPO}}}/blob/{commit}{path}#{line}",
     sitename="{{{PKG}}}.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/templates/docs/make.jl
+++ b/templates/docs/make.jl
@@ -8,7 +8,6 @@ makedocs(;
     authors="{{{AUTHORS}}}",
     sitename="{{{PKG}}}.jl",
     format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
 {{#CANONICAL}}
         canonical="{{{CANONICAL}}}",
 {{/CANONICAL}}

--- a/test/fixtures/AllPlugins/docs/make.jl
+++ b/test/fixtures/AllPlugins/docs/make.jl
@@ -6,7 +6,6 @@ DocMeta.setdocmeta!(AllPlugins, :DocTestSetup, :(using AllPlugins); recursive=tr
 makedocs(;
     modules=[AllPlugins],
     authors="tester",
-    repo="https://github.com/tester/AllPlugins.jl/blob/{commit}{path}#{line}",
     sitename="AllPlugins.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/AllPlugins/docs/make.jl
+++ b/test/fixtures/AllPlugins/docs/make.jl
@@ -8,7 +8,6 @@ makedocs(;
     authors="tester",
     sitename="AllPlugins.jl",
     format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
         edit_link="main",
         assets=String[],
     ),

--- a/test/fixtures/DocumenterGitHubActions/docs/make.jl
+++ b/test/fixtures/DocumenterGitHubActions/docs/make.jl
@@ -6,7 +6,6 @@ DocMeta.setdocmeta!(DocumenterGitHubActions, :DocTestSetup, :(using DocumenterGi
 makedocs(;
     modules=[DocumenterGitHubActions],
     authors="tester",
-    repo="https://github.com/tester/DocumenterGitHubActions.jl/blob/{commit}{path}#{line}",
     sitename="DocumenterGitHubActions.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/DocumenterGitHubActions/docs/make.jl
+++ b/test/fixtures/DocumenterGitHubActions/docs/make.jl
@@ -8,7 +8,6 @@ makedocs(;
     authors="tester",
     sitename="DocumenterGitHubActions.jl",
     format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://tester.github.io/DocumenterGitHubActions.jl",
         edit_link="main",
         assets=String[],

--- a/test/fixtures/DocumenterGitLabCI/docs/make.jl
+++ b/test/fixtures/DocumenterGitLabCI/docs/make.jl
@@ -6,7 +6,6 @@ DocMeta.setdocmeta!(DocumenterGitLabCI, :DocTestSetup, :(using DocumenterGitLabC
 makedocs(;
     modules=[DocumenterGitLabCI],
     authors="tester",
-    repo="https://github.com/tester/DocumenterGitLabCI.jl/blob/{commit}{path}#{line}",
     sitename="DocumenterGitLabCI.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/DocumenterGitLabCI/docs/make.jl
+++ b/test/fixtures/DocumenterGitLabCI/docs/make.jl
@@ -8,7 +8,6 @@ makedocs(;
     authors="tester",
     sitename="DocumenterGitLabCI.jl",
     format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://tester.gitlab.io/DocumenterGitLabCI.jl",
         edit_link="main",
         assets=String[],

--- a/test/fixtures/DocumenterTravis/docs/make.jl
+++ b/test/fixtures/DocumenterTravis/docs/make.jl
@@ -6,7 +6,6 @@ DocMeta.setdocmeta!(DocumenterTravis, :DocTestSetup, :(using DocumenterTravis); 
 makedocs(;
     modules=[DocumenterTravis],
     authors="tester",
-    repo="https://github.com/tester/DocumenterTravis.jl/blob/{commit}{path}#{line}",
     sitename="DocumenterTravis.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/DocumenterTravis/docs/make.jl
+++ b/test/fixtures/DocumenterTravis/docs/make.jl
@@ -8,7 +8,6 @@ makedocs(;
     authors="tester",
     sitename="DocumenterTravis.jl",
     format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
         canonical="https://tester.github.io/DocumenterTravis.jl",
         edit_link="main",
         assets=String[],

--- a/test/fixtures/WackyOptions/docs/make.jl
+++ b/test/fixtures/WackyOptions/docs/make.jl
@@ -6,7 +6,6 @@ DocMeta.setdocmeta!(WackyOptions, :DocTestSetup, :(using WackyOptions); recursiv
 makedocs(;
     modules=[WackyOptions],
     authors="tester",
-    repo="https://x.com/tester/WackyOptions.jl/blob/{commit}{path}#{line}",
     sitename="WackyOptions.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",

--- a/test/fixtures/WackyOptions/docs/make.jl
+++ b/test/fixtures/WackyOptions/docs/make.jl
@@ -8,7 +8,6 @@ makedocs(;
     authors="tester",
     sitename="WackyOptions.jl",
     format=Documenter.HTML(;
-        prettyurls=get(ENV, "CI", "false") == "true",
         canonical="http://example.com",
         edit_link=:commit,
         assets=[


### PR DESCRIPTION
Avoids the following warning by letting Documenter infer the repository instead of giving `repo::String`:
```julia
┌ Warning: Unable to determine the repository root URL for the navbar link.
│ This can happen when a string is passed to the `repo` keyword of `makedocs`.
│ 
│ To remove this warning, either pass a Remotes.Remote object to `repo` to completely
│ specify the remote repository, or explicitly set the remote URL by setting `repolink`
│ via `makedocs(format = HTML(repolink = "..."), ...)`.
└ @ Documenter.HTMLWriter ~/.julia/packages/Documenter/1HwWe/src/html/HTMLWriter.jl:707
```

The alternative would be to provide an explicit `Remotes.GitHub`, `Remotes.GitLab` or `Remotes.URL` depending on the host (see the release notes https://documenter.juliadocs.org/v1.0.0/release-notes/).
Not sure which is best.

Is this enough to fix #430?