### PR TITLE
Run reference tests on 1.10 instead of 1.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         version:
           - "1.0"  # LTS
+          - "1.7"  # interactive tests require <= 1.8
           - "1"    # Latest Release
         os:
           - ubuntu-latest
@@ -42,7 +43,7 @@ jobs:
           # require this specific job to pass on all PRs
           # (see Settings > Branches > Branch protection rules).
           - os: ubuntu-latest
-            version: 1.7.2
+            version: 1.10.0
             arch: x64
     steps:
       - uses: actions/checkout@v4

--- a/test/fixtures/AllPlugins/.appveyor.yml
+++ b/test/fixtures/AllPlugins/.appveyor.yml
@@ -2,7 +2,7 @@
 environment:
   matrix:
     - julia_version: 1.0
-    - julia_version: 1.7
+    - julia_version: 1.10
     - julia_version: nightly
 platform:
   - x64

--- a/test/fixtures/AllPlugins/.cirrus.yml
+++ b/test/fixtures/AllPlugins/.cirrus.yml
@@ -6,7 +6,7 @@ task:
     folder: ~/.julia/artifacts
   env:
     JULIA_VERSION: 1.0
-    JULIA_VERSION: 1.7
+    JULIA_VERSION: 1.10
     JULIA_VERSION: nightly
   install_script:
     - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"

--- a/test/fixtures/AllPlugins/.drone.star
+++ b/test/fixtures/AllPlugins/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   pipelines = []
   for arch in ["amd64"]:
-    for julia in ["1.0", "1.7"]:
+    for julia in ["1.0", "1.10"]:
       pipelines.append(pipeline(arch, julia))
   return pipelines
 

--- a/test/fixtures/AllPlugins/.github/workflows/CI.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.7'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/test/fixtures/AllPlugins/.gitlab-ci.yml
+++ b/test/fixtures/AllPlugins/.gitlab-ci.yml
@@ -21,8 +21,8 @@ Julia 1.0:
   extends:
     - .script
     - .coverage
-Julia 1.7:
-  image: julia:1.7
+Julia 1.10:
+  image: julia:1.10
   extends:
     - .script
     - .coverage

--- a/test/fixtures/AllPlugins/.travis.yml
+++ b/test/fixtures/AllPlugins/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   email: false
 julia:
   - 1.0
-  - 1.7
+  - 1.10
   - nightly
 os:
   - linux

--- a/test/fixtures/Basic/.github/workflows/CI.yml
+++ b/test/fixtures/Basic/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.7'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.7'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.7'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/test/fixtures/DocumenterGitLabCI/.gitlab-ci.yml
+++ b/test/fixtures/DocumenterGitLabCI/.gitlab-ci.yml
@@ -21,8 +21,8 @@ Julia 1.0:
   extends:
     - .script
     - .coverage
-Julia 1.7:
-  image: julia:1.7
+Julia 1.10:
+  image: julia:1.10
   extends:
     - .script
     - .coverage

--- a/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1.0'
-          - '1.7'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/test/fixtures/DocumenterTravis/.travis.yml
+++ b/test/fixtures/DocumenterTravis/.travis.yml
@@ -4,7 +4,7 @@ notifications:
   email: false
 julia:
   - 1.0
-  - 1.7
+  - 1.10
   - nightly
 os:
   - linux

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.10'
           - '1.2'
-          - '1.7'
           - 'nightly'
         os:
         arch:

--- a/test/fixtures/WackyOptions/Manifest.toml
+++ b/test/fixtures/WackyOptions/Manifest.toml
@@ -1,6 +1,7 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.2"
+julia_version = "1.10.0"
 manifest_format = "2.0"
+project_hash = "4cda5991eecc2e1d07ef87b0be009754a63f367f"
 
 [deps]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,10 +107,10 @@ mktempdir() do dir
                 include("git.jl")
 
                 # Quite a bit of output depends on the Julia version,
-                # and the test fixtures are made with Julia 1.7.
+                # and the test fixtures are made with Julia 1.10.0
                 # TODO: Keep this on the latest stable Julia version, and update
                 # the version used by the corresponding CI job at the same time.
-                REFERENCE_VERSION = v"1.7.2"
+                REFERENCE_VERSION = v"1.10.0"
                 if VERSION == REFERENCE_VERSION
                     # Ideally we'd use `with_clean_gitconfig`, but it's way too slow.
                     branch = LibGit2.getconfig(


### PR DESCRIPTION
How I proceeded (might be useful for future updates)

1. change `test/runtests.jl` to run reference tests on v1.10.0
2. change `.github/workflows/CI.yml` to ensure that v1.10.0 is part of CI
3. go to `test/reference.jl`, comment out the following block and replace it with `copy_file(comparison, reference)`

```julia
    if PROMPT
        while true
            println("Update reference file? [y/n]")
            answer = lowercase(strip(readline()))
            if startswith(answer, "y") || startswith(answer, "n")
                # If the user chooses to update the reference file,
                # replace its contents with the comparison file.
                startswith(answer, "y") && copy_file(comparison, reference)
                break
            end
        end
    end
```

4. run the tests
5. revert the changes to `test/reference.jl`