### PR TITLE
Switch default julia compat to 1.6.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         version:
           - "1.0"  # LTS
+          - "1.7" # interactive tests require <= 1.8
           - "1"    # Latest Release
         os:
           - ubuntu-latest

--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -404,8 +404,9 @@ function collect_versions(t::Template, versions::Vector)
     vs = map(v -> lstrip(v, 'v'), [format_version(t.julia); custom])
     filter!(vs) do v
         # Throw away any versions lower than the template's minimum.
+        # but v1.6 should be accepted as a CI number even when t.julia = v1.6.7
         try
-            VersionNumber(v) >= t.julia
+            Base.thisminor(VersionNumber(v)) >= Base.thisminor(t.julia)
         catch e
             e isa ArgumentError || rethrow()
             true

--- a/src/template.jl
+++ b/src/template.jl
@@ -1,5 +1,5 @@
 default_user() = LibGit2.getconfig("github.user", "")
-default_version() = VersionNumber(VERSION.major)
+default_version() = v"1.6.7"  # LTS as of Jan 2024, see https://julialang.org/downloads/#long_term_support_release
 default_plugins() = [
     CompatHelper(),
     ProjectFile(),

--- a/test/fixtures/AllPlugins/.appveyor.yml
+++ b/test/fixtures/AllPlugins/.appveyor.yml
@@ -1,7 +1,7 @@
 # Documentation: https://github.com/JuliaCI/Appveyor.jl
 environment:
   matrix:
-    - julia_version: 1.0
+    - julia_version: 1.6
     - julia_version: 1.7
     - julia_version: nightly
 platform:

--- a/test/fixtures/AllPlugins/.cirrus.yml
+++ b/test/fixtures/AllPlugins/.cirrus.yml
@@ -5,7 +5,7 @@ task:
   artifacts_cache:
     folder: ~/.julia/artifacts
   env:
-    JULIA_VERSION: 1.0
+    JULIA_VERSION: 1.6
     JULIA_VERSION: 1.7
     JULIA_VERSION: nightly
   install_script:

--- a/test/fixtures/AllPlugins/.drone.star
+++ b/test/fixtures/AllPlugins/.drone.star
@@ -1,7 +1,7 @@
 def main(ctx):
   pipelines = []
   for arch in ["amd64"]:
-    for julia in ["1.0", "1.7"]:
+    for julia in ["1.6", "1.7"]:
       pipelines.append(pipeline(arch, julia))
   return pipelines
 

--- a/test/fixtures/AllPlugins/.github/workflows/CI.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1.7'
           - 'nightly'
         os:

--- a/test/fixtures/AllPlugins/.gitlab-ci.yml
+++ b/test/fixtures/AllPlugins/.gitlab-ci.yml
@@ -16,8 +16,8 @@
         c, t = get_summary(process_folder())
         using Printf
         @printf "Test coverage %.2f%%\n" 100c / t'
-Julia 1.0:
-  image: julia:1.0
+Julia 1.6:
+  image: julia:1.6
   extends:
     - .script
     - .coverage

--- a/test/fixtures/AllPlugins/.travis.yml
+++ b/test/fixtures/AllPlugins/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 notifications:
   email: false
 julia:
-  - 1.0
+  - 1.6
   - 1.7
   - nightly
 os:

--- a/test/fixtures/AllPlugins/Project.toml
+++ b/test/fixtures/AllPlugins/Project.toml
@@ -4,7 +4,7 @@ authors = ["tester"]
 version = "1.0.0-DEV"
 
 [compat]
-julia = "1"
+julia = "1.6.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/fixtures/Basic/.github/workflows/CI.yml
+++ b/test/fixtures/Basic/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1.7'
           - 'nightly'
         os:

--- a/test/fixtures/Basic/Project.toml
+++ b/test/fixtures/Basic/Project.toml
@@ -4,7 +4,7 @@ authors = ["tester"]
 version = "1.0.0-DEV"
 
 [compat]
-julia = "1"
+julia = "1.6.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1.7'
           - 'nightly'
         os:

--- a/test/fixtures/DocumenterGitHubActions/Project.toml
+++ b/test/fixtures/DocumenterGitHubActions/Project.toml
@@ -4,7 +4,7 @@ authors = ["tester"]
 version = "1.0.0-DEV"
 
 [compat]
-julia = "1"
+julia = "1.6.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1.7'
           - 'nightly'
         os:

--- a/test/fixtures/DocumenterGitLabCI/.gitlab-ci.yml
+++ b/test/fixtures/DocumenterGitLabCI/.gitlab-ci.yml
@@ -16,8 +16,8 @@
         c, t = get_summary(process_folder())
         using Printf
         @printf "Test coverage %.2f%%\n" 100c / t'
-Julia 1.0:
-  image: julia:1.0
+Julia 1.6:
+  image: julia:1.6
   extends:
     - .script
     - .coverage
@@ -27,7 +27,7 @@ Julia 1.7:
     - .script
     - .coverage
 pages:
-  image: julia:1.0
+  image: julia:1.6
   stage: deploy
   script:
     - |

--- a/test/fixtures/DocumenterGitLabCI/Project.toml
+++ b/test/fixtures/DocumenterGitLabCI/Project.toml
@@ -4,7 +4,7 @@ authors = ["tester"]
 version = "1.0.0-DEV"
 
 [compat]
-julia = "1"
+julia = "1.6.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1.7'
           - 'nightly'
         os:

--- a/test/fixtures/DocumenterTravis/.travis.yml
+++ b/test/fixtures/DocumenterTravis/.travis.yml
@@ -3,7 +3,7 @@ language: julia
 notifications:
   email: false
 julia:
-  - 1.0
+  - 1.6
   - 1.7
   - nightly
 os:

--- a/test/fixtures/DocumenterTravis/Project.toml
+++ b/test/fixtures/DocumenterTravis/Project.toml
@@ -4,7 +4,7 @@ authors = ["tester"]
 version = "1.0.0-DEV"
 
 [compat]
-julia = "1"
+julia = "1.6.7"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -24,6 +24,7 @@ jobs:
       matrix:
         version:
           - '1.2'
+          - '1.6'
           - '1.7'
           - 'nightly'
         os:

--- a/test/interactive.jl
+++ b/test/interactive.jl
@@ -85,7 +85,6 @@ end
         end
 
         @testset "Custom options, accept defaults" begin
-            nversions_to_compat = PkgTemplates.default_version().minor
             print(
                 stdin.buffer,
                 ALL, DONE,        # Customize all fields
@@ -93,12 +92,12 @@ end
                 LF,               # Enter authors
                 LF,               # Enter dir
                 CR,               # Enter host
-                DOWN^nversions_to_compat, CR,               # Enter julia
+                CR,               # Enter julia
                 SELECT_DEFAULTS,  # Pre-select default plugins
                 DONE,             # Select no additional plugins
                 DONE^NDEFAULTS,   # Don't customize plugins
             )
-            @test Template(; interactive=true) == Template(; user="user")
+            @test Template(; interactive=true) == Template(; user="user", julia=v"1.0.0")
             readavailable(stdin.buffer)
         end
 

--- a/test/interactive.jl
+++ b/test/interactive.jl
@@ -85,6 +85,7 @@ end
         end
 
         @testset "Custom options, accept defaults" begin
+            nversions_to_compat = PkgTemplates.default_version().minor
             print(
                 stdin.buffer,
                 ALL, DONE,        # Customize all fields
@@ -92,7 +93,7 @@ end
                 LF,               # Enter authors
                 LF,               # Enter dir
                 CR,               # Enter host
-                CR,               # Enter julia
+                DOWN^nversions_to_compat, CR,               # Enter julia
                 SELECT_DEFAULTS,  # Pre-select default plugins
                 DONE,             # Select no additional plugins
                 DONE^NDEFAULTS,   # Don't customize plugins

--- a/test/show.jl
+++ b/test/show.jl
@@ -31,7 +31,7 @@ end
               authors: ["$USER"]
               dir: "$(contractuser(Pkg.devdir()))"
               host: "github.com"
-              julia: v"1.0.0"
+              julia: v"1.6.7"
               user: "$USER"
               plugins:
                 CompatHelper:
@@ -58,7 +58,7 @@ end
                   x64: true
                   x86: false
                   coverage: true
-                  extra_versions: [\"1.0\", \"$(VERSION.major).$(VERSION.minor)\", \"nightly\"]
+                  extra_versions: [\"1.6\", \"$(VERSION.major).$(VERSION.minor)\", \"nightly\"]
                 License:
                   path: "$(joinpath(LICENSES_DIR, "MIT"))"
                   destination: "LICENSE"


### PR DESCRIPTION
Most interesting changes:

- `src/template.jl`
- `src/plugins/ci.jl`
- `test/interactive`
- `test/show`

I still need advice on how to modify the interactive tests. For now we can only pick a 1.x.0, and it would be nice to have a default 1.6.7, right?