### PR TITLE
Allow docs/make.jl to be run from the root of the repo

### DIFF
--- a/templates/docs/make.jl
+++ b/templates/docs/make.jl
@@ -1,3 +1,5 @@
+insert!(LOAD_PATH, 1, joinpath(@__DIR__, ".."))
+
 using {{{PKG}}}
 using Documenter
 


### PR DESCRIPTION
Add the repo root to LOAD_PATH so that docs/make.jl can be run from the repo root as well as from the docs directory.