### PR TITLE
github template: Bump julia-actions/setup-julia to v2

### DIFF
--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -48,7 +48,7 @@ jobs:
         <</EXCLUDES>>
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -78,7 +78,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/cache@v1

--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -52,7 +52,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       <<#HAS_CODECOV>>
@@ -81,7 +81,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/test/fixtures/AllPlugins/.github/workflows/CI.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/test/fixtures/AllPlugins/.github/workflows/CI.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/test/fixtures/Basic/.github/workflows/CI.yml
+++ b/test/fixtures/Basic/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/test/fixtures/Basic/.github/workflows/CI.yml
+++ b/test/fixtures/Basic/.github/workflows/CI.yml
@@ -36,6 +36,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -48,7 +48,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/cache@v1

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
   docs:
@@ -51,7 +51,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
@@ -36,6 +36,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
           - x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}

--- a/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
@@ -36,6 +36,6 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
   docs:
@@ -52,7 +52,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
           - x86
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -49,7 +49,7 @@ jobs:
       statuses: write
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
       - uses: julia-actions/cache@v1


### PR DESCRIPTION
I just noticed that the github action template still uses `julia-actions/setup-julia@v1`.  Bump that to v2.