### PR TITLE
Use "pre" instead of "nightly" for GitHub CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.50"
+version = "0.7.51"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -7,7 +7,7 @@ Strings are left in their original form.
 format_version(v::VersionNumber) = "$(v.major).$(v.minor)"
 format_version(v::AbstractString) = string(v)
 
-const ALLOWED_FAILURES = ["nightly"]
+const ALLOWED_FAILURES = ["nightly"]  # TODO: Update this list with new RCs.
 const DEFAULT_CI_VERSIONS = map(format_version, [default_version(), VERSION, "nightly"])
 const DEFAULT_CI_VERSIONS_GITHUB = map(format_version, [default_version(), VERSION, "pre"])
 const DEFAULT_CI_VERSIONS_NO_PRERELEASE = map(format_version, [default_version(), VERSION])

--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -7,9 +7,10 @@ Strings are left in their original form.
 format_version(v::VersionNumber) = "$(v.major).$(v.minor)"
 format_version(v::AbstractString) = string(v)
 
-const ALLOWED_FAILURES = ["nightly"]  # TODO: Update this list with new RCs.
+const ALLOWED_FAILURES = ["nightly"]
 const DEFAULT_CI_VERSIONS = map(format_version, [default_version(), VERSION, "nightly"])
-const DEFAULT_CI_VERSIONS_NO_NIGHTLY = map(format_version, [default_version(), VERSION])
+const DEFAULT_CI_VERSIONS_GITHUB = map(format_version, [default_version(), VERSION, "pre"])
+const DEFAULT_CI_VERSIONS_NO_PRERELEASE = map(format_version, [default_version(), VERSION])
 const EXTRA_VERSIONS_DOC = "- `extra_versions::Vector`: Extra Julia versions to test, as strings or `VersionNumber`s."
 
 """
@@ -22,7 +23,7 @@ const EXTRA_VERSIONS_DOC = "- `extra_versions::Vector`: Extra Julia versions to 
         x64=true,
         x86=false,
         coverage=true,
-        extra_versions=$DEFAULT_CI_VERSIONS,
+        extra_versions=$DEFAULT_CI_VERSIONS_GITHUB,
     )
 
 Integrates your packages with [GitHub Actions](https://github.com/features/actions).
@@ -153,7 +154,7 @@ function view(p::TravisCI, t::Template, pkg::AbstractString)
     if p.arm64
         p.osx && push!(excludes, Dict("E_OS" => "osx", "E_ARCH" => "arm64"))
         p.windows && push!(excludes, Dict("E_OS" => "windows", "E_ARCH" => "arm64"))
-        "nightly" in versions && push!(excludes, Dict("E_JULIA" => "nightly", "E_ARCH" => "arm64"))
+        "pre" in versions && push!(excludes, Dict("E_JULIA" => "pre", "E_ARCH" => "arm64"))
     end
 
     return Dict(
@@ -283,7 +284,7 @@ end
     GitLabCI(;
         file="$(contractuser(default_file("gitlab-ci.yml")))",
         coverage=true,
-        extra_versions=$DEFAULT_CI_VERSIONS_NO_NIGHTLY,
+        extra_versions=$DEFAULT_CI_VERSIONS_NO_PRERELEASE,
     )
 
 Integrates your packages with [GitLab CI](https://docs.gitlab.com/ce/ci).
@@ -304,7 +305,7 @@ See [`Documenter`](@ref) for more information.
     file::String = default_file("gitlab-ci.yml")
     coverage::Bool = true
     # Nightly has no Docker image.
-    extra_versions::Vector = DEFAULT_CI_VERSIONS_NO_NIGHTLY
+    extra_versions::Vector = DEFAULT_CI_VERSIONS_NO_PRERELEASE
 end
 
 gitignore(p::GitLabCI) = p.coverage ? COVERAGE_GITIGNORE : String[]
@@ -344,7 +345,7 @@ end
         amd64=true,
         arm=false,
         arm64=false,
-        extra_versions=$DEFAULT_CI_VERSIONS_NO_NIGHTLY,
+        extra_versions=$DEFAULT_CI_VERSIONS_NO_PRERELEASE,
     )
 
 Integrates your packages with [Drone CI](https://drone.io).
@@ -367,7 +368,7 @@ $EXTRA_VERSIONS_DOC
     amd64::Bool = true
     arm::Bool = false
     arm64::Bool = false
-    extra_versions::Vector = DEFAULT_CI_VERSIONS_NO_NIGHTLY
+    extra_versions::Vector = DEFAULT_CI_VERSIONS_NO_PRERELEASE
 end
 
 source(p::DroneCI) = p.file

--- a/src/plugins/ci.jl
+++ b/src/plugins/ci.jl
@@ -54,7 +54,7 @@ $EXTRA_VERSIONS_DOC
     x64::Bool = true
     x86::Bool = false
     coverage::Bool = true
-    extra_versions::Vector = DEFAULT_CI_VERSIONS
+    extra_versions::Vector = DEFAULT_CI_VERSIONS_GITHUB
 end
 
 source(p::GitHubActions) = p.file

--- a/test/fixtures/AllPlugins/.github/workflows/CI.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         version:
           - '1.10'
           - '1.6'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/test/fixtures/Basic/.github/workflows/CI.yml
+++ b/test/fixtures/Basic/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         version:
           - '1.10'
           - '1.6'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         version:
           - '1.10'
           - '1.6'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterGitLabCI/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         version:
           - '1.10'
           - '1.6'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
+++ b/test/fixtures/DocumenterTravis/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
         version:
           - '1.10'
           - '1.6'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/test/fixtures/WackyOptions/.github/workflows/CI.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CI.yml
@@ -26,7 +26,7 @@ jobs:
           - '1.10'
           - '1.2'
           - '1.6'
-          - 'nightly'
+          - 'pre'
         os:
         arch:
           - x64

--- a/test/show.jl
+++ b/test/show.jl
@@ -58,7 +58,7 @@ end
                   x64: true
                   x86: false
                   coverage: true
-                  extra_versions: [\"1.6\", \"$(VERSION.major).$(VERSION.minor)\", \"nightly\"]
+                  extra_versions: [\"1.6\", \"$(VERSION.major).$(VERSION.minor)\", \"pre\"]
                 License:
                   path: "$(joinpath(LICENSES_DIR, "MIT"))"
                   destination: "LICENSE"


### PR DESCRIPTION
Partial fix for #474 

Changing the LTS is slightly more involved so let's start with avoiding nightly