### PR TITLE
Switch default version to 1.10.4

### DIFF
--- a/src/template.jl
+++ b/src/template.jl
@@ -1,5 +1,5 @@
 default_user() = LibGit2.getconfig("github.user", "")
-default_version() = v"1.6.7"  # LTS as of Jan 2024, see https://julialang.org/downloads/#long_term_support_release
+default_version() = v"1.10.4"  # LTS as of July 2024, see https://julialang.org/downloads/#long_term_support_release
 default_plugins() = [
     CompatHelper(),
     ProjectFile(),


### PR DESCRIPTION
As of a few hours ago 1.10.4 is the LTS

not sure how much this breaks in the tests.
I bet it does, but i hope it doesn't
Will follow up to fix those if needed

Not sure if should also update our CI setup