### PR TITLE
support JULIA_REFERENCETESTS_UPDATE env var in tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,7 +43,7 @@ jobs:
           # require this specific job to pass on all PRs
           # (see Settings > Branches > Branch protection rules).
           - os: ubuntu-latest
-            version: 1.10.0
+            version: 1.10.6
             arch: x64
     steps:
       - uses: actions/checkout@v4

--- a/test/fixtures/WackyOptions/Manifest.toml
+++ b/test/fixtures/WackyOptions/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.0"
+julia_version = "1.10.6"
 manifest_format = "2.0"
 project_hash = "4cda5991eecc2e1d07ef87b0be009754a63f367f"
 

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -32,7 +32,7 @@ function test_reference(reference, comparison)
     println("Reference: $reference")
     println("Comparison: $comparison")
     update = false
-    if haskey(ENV, "UPDATE_REFERENCE_FILES")
+    if haskey(ENV, "JULIA_REFERENCETESTS_UPDATE")
         copy_file(comparison, reference)
     elseif PROMPT
         while true

--- a/test/reference.jl
+++ b/test/reference.jl
@@ -32,7 +32,9 @@ function test_reference(reference, comparison)
     println("Reference: $reference")
     println("Comparison: $comparison")
     update = false
-    if PROMPT
+    if haskey(ENV, "UPDATE_REFERENCE_FILES")
+        copy_file(comparison, reference)
+    elseif PROMPT
         while true
             println("Update reference file? [y/n]")
             answer = lowercase(strip(readline()))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -110,7 +110,7 @@ mktempdir() do dir
                 # and the test fixtures are made with Julia 1.10.0
                 # TODO: Keep this on the latest stable Julia version, and update
                 # the version used by the corresponding CI job at the same time.
-                REFERENCE_VERSION = v"1.10.0"
+                REFERENCE_VERSION = v"1.10.6"
                 if VERSION == REFERENCE_VERSION
                     # Ideally we'd use `with_clean_gitconfig`, but it's way too slow.
                     branch = LibGit2.getconfig(


### PR DESCRIPTION
to disable the interactive prompt as it was somehow broken for me locally. Also bumps the Julia version for reference tests to 1.10.6