### PR TITLE
Add `repl_history.jl` to default ignore

### DIFF
--- a/src/plugins/git.jl
+++ b/src/plugins/git.jl
@@ -2,7 +2,7 @@ const DEFAULT_DEFAULT_BRANCH = "main"
 
 """
     Git(;
-        ignore=String[],
+        ignore=["repl_history.jl"],
         name=nothing,
         email=nothing,
         branch=LibGit2.getconfig("init.defaultBranch", "$DEFAULT_DEFAULT_BRANCH")
@@ -29,7 +29,7 @@ Creates a Git repository and a `.gitignore` file.
   and for you to have a GPG key associated with your committer identity.
 """
 @plugin struct Git <: Plugin
-    ignore::Vector{String} = String[]
+    ignore::Vector{String} = ["repl_history.jl"]
     name::Union{String, Nothing} = nothing
     email::Union{String, Nothing} = nothing
     branch::String = @mock(LibGit2.getconfig("init.defaultBranch", DEFAULT_DEFAULT_BRANCH))

--- a/test/fixtures/AllPlugins/.gitignore
+++ b/test/fixtures/AllPlugins/.gitignore
@@ -4,3 +4,4 @@
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/
+repl_history.jl

--- a/test/fixtures/Basic/.gitignore
+++ b/test/fixtures/Basic/.gitignore
@@ -1,1 +1,2 @@
 /Manifest.toml
+repl_history.jl

--- a/test/fixtures/DocumenterGitHubActions/.gitignore
+++ b/test/fixtures/DocumenterGitHubActions/.gitignore
@@ -1,3 +1,4 @@
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/
+repl_history.jl

--- a/test/fixtures/DocumenterGitLabCI/.gitignore
+++ b/test/fixtures/DocumenterGitLabCI/.gitignore
@@ -4,3 +4,4 @@
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/
+repl_history.jl

--- a/test/fixtures/DocumenterTravis/.gitignore
+++ b/test/fixtures/DocumenterTravis/.gitignore
@@ -1,3 +1,4 @@
 /Manifest.toml
 /docs/Manifest.toml
 /docs/build/
+repl_history.jl

--- a/test/show.jl
+++ b/test/show.jl
@@ -41,7 +41,7 @@ end
                 Dependabot:
                   file: "$(joinpath(TEMPLATES_DIR, "github", "dependabot.yml"))"
                 Git:
-                  ignore: String[]
+                  ignore: ["repl_history.jl"]
                   name: nothing
                   email: nothing
                   branch: "main"


### PR DESCRIPTION
If you start Julia with

    $ JULIA_HISTORY=repl_history.jl julia --project

then the session history gets stored locally in the project directory
rather than your global `logs` folder. It's very unlikely that you want
to commit this file.

It might make some sense to ignore this file by default. On the other hand, since you can choose any name for it, perhaps this doesn't make much sense. I thought I'd submit the PR for consideration, but if the maintainers would rather just close it without merging, that's fine with me.