### PR TITLE
Typo in tests.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PkgTemplates"
 uuid = "14b8a8f1-9102-5b29-a752-f990bacb7fe1"
 authors = ["Chris de Graaf", "Invenia Technical Computing Corporation"]
-version = "0.7.54"
+version = "0.7.55"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/plugins/tests.jl
+++ b/src/plugins/tests.jl
@@ -94,7 +94,7 @@ function validate(p::Tests, t::Template)
         if !(val isa Bool)
             throw(ArgumentError("Aqua keyword arguments must have boolean values"))
         elseif !(key in aqua_kwargs_names)
-            throw(ArgumentError("Aqua keyword arguments must belong to $aqua_kwarg_names"))
+            throw(ArgumentError("Aqua keyword arguments must belong to $aqua_kwargs_names"))
         end
     end
 end


### PR DESCRIPTION
The typo in interpolation of a variable name results in `UndefVarError: aqua_kwarg_names not defined in PkgTemplates` instead of desired explanation of the actual error