### PR TITLE
Remove 'Configure doc environment' step from CI.yml - docs

### DIFF
--- a/templates/github/workflows/CI.yml
+++ b/templates/github/workflows/CI.yml
@@ -82,12 +82,6 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v2
-      - name: Configure doc environment
-        shell: julia --project=docs --color=yes {0}
-        run: |
-          using Pkg
-          Pkg.develop(PackageSpec(path=pwd()))
-          Pkg.instantiate()
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-docdeploy@v1
         env:


### PR DESCRIPTION
julia-actions/julia-docdeploy already does documentation specific environment instantiation