### PR TITLE
Update CompatHelper.jl workflow files

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -9,10 +9,12 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Install CompatHelper
+        run: using Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: using CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/templates/github/workflows/CompatHelper.yml
+++ b/templates/github/workflows/CompatHelper.yml
@@ -7,10 +7,12 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Install CompatHelper
+        run: using Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: using CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/test/fixtures/AllPlugins/.github/workflows/CompatHelper.yml
+++ b/test/fixtures/AllPlugins/.github/workflows/CompatHelper.yml
@@ -7,10 +7,12 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Install CompatHelper
+        run: using Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: using CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/test/fixtures/Basic/.github/workflows/CompatHelper.yml
+++ b/test/fixtures/Basic/.github/workflows/CompatHelper.yml
@@ -7,10 +7,12 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Install CompatHelper
+        run: using Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: using CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/test/fixtures/DocumenterGitHubActions/.github/workflows/CompatHelper.yml
+++ b/test/fixtures/DocumenterGitHubActions/.github/workflows/CompatHelper.yml
@@ -7,10 +7,12 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Install CompatHelper
+        run: using Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: using CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/test/fixtures/DocumenterGitLabCI/.github/workflows/CompatHelper.yml
+++ b/test/fixtures/DocumenterGitLabCI/.github/workflows/CompatHelper.yml
@@ -7,10 +7,12 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Install CompatHelper
+        run: using Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: using CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/test/fixtures/DocumenterTravis/.github/workflows/CompatHelper.yml
+++ b/test/fixtures/DocumenterTravis/.github/workflows/CompatHelper.yml
@@ -7,10 +7,12 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Install CompatHelper
+        run: using Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: using CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/test/fixtures/WackyOptions/.github/workflows/CompatHelper.yml
+++ b/test/fixtures/WackyOptions/.github/workflows/CompatHelper.yml
@@ -7,10 +7,12 @@ jobs:
   CompatHelper:
     runs-on: ubuntu-latest
     steps:
-      - name: Pkg.add("CompatHelper")
-        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: Install CompatHelper
+        run: using Pkg; Pkg.add("CompatHelper")
+        shell: julia --color=yes {0}
+      - name: Run CompatHelper
+        run: using CompatHelper; CompatHelper.main()
+        shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}
-        run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
- Use `shell:` option to launch julia directly
- Give each step a simpler name