### PR TITLE
Soft coding version number in Citation plugin (#389)

### DIFF
--- a/src/plugins/citation.jl
+++ b/src/plugins/citation.jl
@@ -22,6 +22,7 @@ view(::Citation, t::Template, pkg::AbstractString) = Dict(
     "MONTH" => month(today()),
     "PKG" => pkg,
     "URL" => "https://$(t.host)/$(t.user)/$pkg.jl",
+    "VERSION" => "v$(first([p for p in t.plugins if p isa ProjectFile]).version)",
     "YEAR" => year(today()),
 )
 

--- a/templates/CITATION.bib
+++ b/templates/CITATION.bib
@@ -2,7 +2,7 @@
 	author  = {<<&AUTHORS>>},
 	title   = {<<&PKG>>.jl},
 	url     = {<<&URL>>},
-	version = {v1.0.0-DEV},
+	version = {<<&VERSION>>},
 	year    = {<<&YEAR>>},
 	month   = {<<&MONTH>>}
 }

--- a/test/fixtures/WackyOptions/CITATION.bib
+++ b/test/fixtures/WackyOptions/CITATION.bib
@@ -2,7 +2,7 @@
 	author  = {tester},
 	title   = {WackyOptions.jl},
 	url     = {https://x.com/tester/WackyOptions.jl},
-	version = {v1.0.0-DEV},
+	version = {v1.0.0},
 	year    = {2019},
 	month   = {8}
 }


### PR DESCRIPTION
This PR fixes issue #389: "Version number in Citation plugin is hard-coded."
The version information is now obtained from the argument `t` in `view(::Citation, t::Template, pkg::AbstractString)`. For reference, here is a generated `CITATION.bib` file based on [this example](https://gist.github.com/ohno/f3b1eb2c8f3a7e6803c34c8aab56e869):
```
@misc{FewBodyHamiltonians.jl,
	author  = {Shuhei Ohno, Martin Mikkelsen},
	title   = {FewBodyHamiltonians.jl},
	url     = {https://github.com/JuliaFewBody/FewBodyHamiltonians.jl},
	version = {v0.0.1},
	year    = {2025},
	month   = {9}
}
```